### PR TITLE
Add the config directory to the install target

### DIFF
--- a/moose_gazebo/CMakeLists.txt
+++ b/moose_gazebo/CMakeLists.txt
@@ -20,7 +20,7 @@ install(DIRECTORY scripts
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
-install(DIRECTORY launch worlds
+install(DIRECTORY launch worlds config
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 


### PR DESCRIPTION
Omitting the config folder prevents the moose_world.launch from launching correctly when installing the packages via apt:
`... file does not exist [/opt/ros/kinetic/share/moose_gazebo/config/control_sim.yaml]`