### PR TITLE
Add the scripts folder to the install target too

### DIFF
--- a/moose_gazebo/CMakeLists.txt
+++ b/moose_gazebo/CMakeLists.txt
@@ -20,7 +20,7 @@ install(DIRECTORY scripts
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
-install(DIRECTORY launch worlds config
+install(DIRECTORY launch worlds config scripts
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 


### PR DESCRIPTION
Follow-up from the previous pull-request.  The scripts folder was also missing from the install target, which breaks the ability to teleoperate the simulation through rviz.