### PR TITLE
Rename spawn launch

### DIFF
--- a/moose_gazebo/CMakeLists.txt
+++ b/moose_gazebo/CMakeLists.txt
@@ -20,7 +20,7 @@ install(DIRECTORY scripts
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
-install(DIRECTORY launch worlds config
+install(DIRECTORY launch worlds config scripts
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 


### PR DESCRIPTION
To keep things consistent with the new sim environments, we're moving all of the robot-spawning launch files to be named "spawn_<robot>.launch".